### PR TITLE
Update wheel build process

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -22,7 +22,9 @@ jobs:
       env:
         # From rio-color here:
         # https://github.com/mapbox/rio-color/blob/0ab59ad8e2db99ad1d0c8bd8c2e4cf8d0c3114cf/appveyor.yml#L3
-        CIBW_SKIP: "cp2* cp35* pp* *-win32 *-manylinux_i686"
+        # Skip Python 3.10 until officially released, as numpy wheels aren't yet
+        # available
+        CIBW_SKIP: "cp2* cp35* cp310* pp* *-win32 *-manylinux_i686"
         CIBW_ARCHS_MACOS: x86_64 arm64 universal2
         CIBW_ARCHS_LINUX: x86_64 aarch64
         CIBW_BEFORE_BUILD: python -m pip install numpy Cython

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -3,8 +3,8 @@ name: Build Wheels
 # Only run on new tags starting with `v`
 on:
   push:
-    tags:
-      - 'v*'
+    # tags:
+    #   - 'v*'
 
 jobs:
   build_wheels:
@@ -12,40 +12,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
-    - name: set environment variables
-      uses: allenevans/set-env@v1.1.0
-      with:
-        # Only build on CPython
-        # PyPy on macos seems to be failing; see https://github.com/joerick/cibuildwheel/issues/402
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.1.1
+      env:
         CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
-        # Run before build
         CIBW_BEFORE_BUILD: python -m pip install numpy Cython
-        # CIBW_BEFORE_TEST: python -m pip install numpy Cython '.[test]'
-        # # run the package tests using `pytest`
-        # CIBW_TEST_COMMAND: pytest
-
-    - uses: actions/setup-python@v1
-      name: Install Python
-      with:
-        python-version: '3.7'
-
-    - name: Install cibuildwheel
-      run: |
-        python -m pip install cibuildwheel==1.4.2
-
-    - name: Install Visual C++ for Python 2.7
-      if: startsWith(matrix.os, 'windows')
-      run: |
-        choco install vcpython27 -f -y
-
-    - name: Build wheel
-      run: |
-        python -m cibuildwheel --output-dir wheelhouse
 
     - uses: actions/upload-artifact@v2
       with:
@@ -60,7 +36,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Build sdist
         run: python setup.py sdist
@@ -69,17 +45,17 @@ jobs:
         with:
           path: dist/*.tar.gz
 
-  upload_pypi:
-    needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: artifact
-          path: dist
-
-      - uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_PASSWORD }}
-          # To test: repository_url: https://test.pypi.org/legacy/
+  # upload_pypi:
+  #   needs: [build_wheels, build_sdist]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: artifact
+  #         path: dist
+  #
+  #     - uses: pypa/gh-action-pypi-publish@master
+  #       with:
+  #         user: __token__
+  #         password: ${{ secrets.PYPI_PASSWORD }}
+  #         # To test: repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -20,7 +20,9 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.1.1
       env:
-        CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
+        # From rio-color here:
+        # https://github.com/mapbox/rio-color/blob/0ab59ad8e2db99ad1d0c8bd8c2e4cf8d0c3114cf/appveyor.yml#L3
+        CIBW_SKIP: "cp2* cp35* pp* *-win32 *-manylinux_i686"
         CIBW_BEFORE_BUILD: python -m pip install numpy Cython
 
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -3,8 +3,8 @@ name: Build Wheels
 # Only run on new tags starting with `v`
 on:
   push:
-    # tags:
-    #   - 'v*'
+    tags:
+      - 'v*'
 
 jobs:
   build_wheels:
@@ -54,17 +54,17 @@ jobs:
         with:
           path: dist/*.tar.gz
 
-  # upload_pypi:
-  #   needs: [build_wheels, build_sdist]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/download-artifact@v2
-  #       with:
-  #         name: artifact
-  #         path: dist
-  #
-  #     - uses: pypa/gh-action-pypi-publish@master
-  #       with:
-  #         user: __token__
-  #         password: ${{ secrets.PYPI_PASSWORD }}
-  #         # To test: repository_url: https://test.pypi.org/legacy/
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_PASSWORD }}
+          # To test: repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -38,6 +38,9 @@ jobs:
         with:
           python-version: '3.8'
 
+      - name: Install build dependencies
+        run: python -m pip install '.[build]'
+
       - name: Build sdist
         run: python setup.py sdist
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -3,8 +3,8 @@ name: Build Wheels
 # Only run on new tags starting with `v`
 on:
   push:
-    tags:
-      - 'v*'
+    # tags:
+    #   - 'v*'
 
 jobs:
   build_wheels:
@@ -26,7 +26,6 @@ jobs:
         # available
         CIBW_SKIP: "cp2* cp35* cp310* pp* *-win32 *-manylinux_i686"
         CIBW_ARCHS_MACOS: x86_64 arm64 universal2
-        CIBW_ARCHS_LINUX: x86_64 aarch64
         CIBW_BEFORE_BUILD: python -m pip install numpy Cython
 
     - uses: actions/upload-artifact@v2
@@ -54,17 +53,17 @@ jobs:
         with:
           path: dist/*.tar.gz
 
-  upload_pypi:
-    needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: artifact
-          path: dist
-
-      - uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_PASSWORD }}
-          # To test: repository_url: https://test.pypi.org/legacy/
+  # upload_pypi:
+  #   needs: [build_wheels, build_sdist]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: artifact
+  #         path: dist
+  #
+  #     - uses: pypa/gh-action-pypi-publish@master
+  #       with:
+  #         user: __token__
+  #         password: ${{ secrets.PYPI_PASSWORD }}
+  #         # To test: repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -23,7 +23,8 @@ jobs:
         # From rio-color here:
         # https://github.com/mapbox/rio-color/blob/0ab59ad8e2db99ad1d0c8bd8c2e4cf8d0c3114cf/appveyor.yml#L3
         CIBW_SKIP: "cp2* cp35* pp* *-win32 *-manylinux_i686"
-        CIBW_ARCHS: all
+        CIBW_ARCHS_MACOS: x86_64 arm64 universal2
+        CIBW_ARCHS_LINUX: x86_64 aarch64
         CIBW_BEFORE_BUILD: python -m pip install numpy Cython
 
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -3,8 +3,8 @@ name: Build Wheels
 # Only run on new tags starting with `v`
 on:
   push:
-    # tags:
-    #   - 'v*'
+    tags:
+      - 'v*'
 
 jobs:
   build_wheels:
@@ -53,17 +53,17 @@ jobs:
         with:
           path: dist/*.tar.gz
 
-  # upload_pypi:
-  #   needs: [build_wheels, build_sdist]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/download-artifact@v2
-  #       with:
-  #         name: artifact
-  #         path: dist
-  #
-  #     - uses: pypa/gh-action-pypi-publish@master
-  #       with:
-  #         user: __token__
-  #         password: ${{ secrets.PYPI_PASSWORD }}
-  #         # To test: repository_url: https://test.pypi.org/legacy/
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_PASSWORD }}
+          # To test: repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -23,6 +23,7 @@ jobs:
         # From rio-color here:
         # https://github.com/mapbox/rio-color/blob/0ab59ad8e2db99ad1d0c8bd8c2e4cf8d0c3114cf/appveyor.yml#L3
         CIBW_SKIP: "cp2* cp35* pp* *-win32 *-manylinux_i686"
+        CIBW_ARCHS: all
         CIBW_BEFORE_BUILD: python -m pip install numpy Cython
 
     - uses: actions/upload-artifact@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+  "setuptools",
+  "wheel",
+  "cython==0.29.24",
+  "oldest-supported-numpy"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[project]
+requires-python = ">=3.6"
+
 [build-system]
 requires = [
   "setuptools",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ with open("README.md") as f:
 inst_reqs = ["numpy"]
 
 extra_reqs = {
-    "test": ["pytest", "pytest-benchmark", "imageio"], }
+    "test": ["pytest", "pytest-benchmark", "imageio"],
+    "build": ["numpy", "Cython"]}
 
 
 # Ref https://suzyahyah.github.io/cython/programming/2018/12/01/Gotchas-in-Cython.html


### PR DESCRIPTION
### Change list

- Update `cibuildwheel`. Should now build wheels for ARM Macs as well.
- Add `build-system` heading to `pyproject.toml` so that development install works correctly.