### PR TITLE
Build musllinux wheels

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -3,8 +3,8 @@ name: Build Wheels
 # Only run on new tags starting with `v`
 on:
   push:
-#    tags:
-#      - 'v*'
+    tags:
+      - 'v*'
 
 jobs:
   build_wheels:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -3,8 +3,8 @@ name: Build Wheels
 # Only run on new tags starting with `v`
 on:
   push:
-    tags:
-      - 'v*'
+#    tags:
+#      - 'v*'
 
 jobs:
   build_wheels:
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.1.1
+      uses: pypa/cibuildwheel@v2.3.0
       env:
         # From rio-color here:
         # https://github.com/mapbox/rio-color/blob/0ab59ad8e2db99ad1d0c8bd8c2e4cf8d0c3114cf/appveyor.yml#L3


### PR DESCRIPTION
I think updating cibuildwheel to 2.3.0 will build musllinux wheels (used on Alpine).

Yeah I updated quantized-mesh-encoder to cibuildwheel 2.3.0 as well and it's also buildling musllinux wheels https://github.com/kylebarron/quantized-mesh-encoder/runs/4423264859?check_suite_focus=true